### PR TITLE
Changed DEFAULT_ARCH to what uname -m reports.

### DIFF
--- a/arch-bootstrap.sh
+++ b/arch-bootstrap.sh
@@ -28,7 +28,7 @@ PACMAN_PACKAGES=(
 BASIC_PACKAGES=(${PACMAN_PACKAGES[*]} filesystem)
 EXTRA_PACKAGES=(coreutils bash grep gawk file tar systemd)
 DEFAULT_REPO_URL="http://mirrors.kernel.org/archlinux"
-DEFAULT_ARCH="i686"
+DEFAULT_ARCH=`uname -m`
 
 # Output to standard error
 stderr() { echo "$@" >&2; }


### PR DESCRIPTION
I believe it'd be a better idea to default to what uname reports as the selected arch. I assume most people will want to use the same arch, and it will help solve problems when someone tries to chroot into a different architecture. 
