### PR TITLE
Add arch support for ARM variants

### DIFF
--- a/arch-bootstrap.sh
+++ b/arch-bootstrap.sh
@@ -61,7 +61,7 @@ uncompress() {
 ###
 get_default_repo() {
   local ARCH=$1
-  if [[ x"$ARCH" != xarm ]]; then
+  if [[ "$ARCH" != arm* ]]; then
     echo $DEFAULT_REPO_URL
   else
     echo $DEFAULT_ARM_REPO_URL
@@ -70,7 +70,7 @@ get_default_repo() {
 
 get_core_repo_url() {
   local REPO_URL=$1 ARCH=$2
-  if [[ x"$ARCH" != xarm ]]; then
+  if [[ "$ARCH" != arm* ]]; then
     echo "${REPO_URL%/}/core/os/$ARCH"
   else
     echo "${REPO_URL%/}/$ARCH/core"
@@ -79,7 +79,7 @@ get_core_repo_url() {
 
 get_template_repo_url() {
   local REPO_URL=$1 ARCH=$2
-  if [[ x"$ARCH" != xarm ]]; then
+  if [[ "$ARCH" != arm* ]]; then
     echo "${REPO_URL%/}/\$repo/os/$ARCH"
   else
     echo "${REPO_URL%/}/$ARCH"
@@ -138,6 +138,7 @@ install_pacman_packages() {
 
 configure_static_qemu() {
   local ARCH=$1 DEST=$2
+  [[ "$ARCH" == arm* ]] && ARCH=arm
   QEMU_STATIC_BIN=$(which qemu-$ARCH-static || echo )
   [[ -e "$QEMU_STATIC_BIN" ]] ||\
     { debug "no static qemu for $ARCH, ignoring"; return 0; }

--- a/arch-bootstrap.sh
+++ b/arch-bootstrap.sh
@@ -61,28 +61,28 @@ uncompress() {
 ###
 get_default_repo() {
   local ARCH=$1
-  if [[ "$ARCH" != arm* ]]; then
-    echo $DEFAULT_REPO_URL
-  else
+  if [[ "$ARCH" == arm* ]]; then
     echo $DEFAULT_ARM_REPO_URL
+  else
+    echo $DEFAULT_REPO_URL
   fi
 }
 
 get_core_repo_url() {
   local REPO_URL=$1 ARCH=$2
-  if [[ "$ARCH" != arm* ]]; then
-    echo "${REPO_URL%/}/core/os/$ARCH"
-  else
+  if [[ "$ARCH" == arm* ]]; then
     echo "${REPO_URL%/}/$ARCH/core"
+  else
+    echo "${REPO_URL%/}/core/os/$ARCH"
   fi
 }
 
 get_template_repo_url() {
   local REPO_URL=$1 ARCH=$2
-  if [[ "$ARCH" != arm* ]]; then
-    echo "${REPO_URL%/}/\$repo/os/$ARCH"
-  else
+  if [[ "$ARCH" == arm* ]]; then
     echo "${REPO_URL%/}/$ARCH"
+  else
+    echo "${REPO_URL%/}/\$repo/os/$ARCH"
   fi
 }
 


### PR DESCRIPTION
`$ARCH` comparisons now check for strings beginning with `arm`. This allows bootstrapping with specific ARM architectures in mind:

    arch-bootstrap -q -a armv7h target

Previously, this would have failed due to the use of the wrong repository mirror and non-existent qemu-user-static binary.