### PR TITLE
Add -L option to follow url redirection.

### DIFF
--- a/arch-bootstrap.sh
+++ b/arch-bootstrap.sh
@@ -44,7 +44,7 @@ extract_href() {
 }
 
 fetch() {
-  curl -s "$@"
+  curl -L -s "$@"
 }
 
 uncompress() {


### PR DESCRIPTION
This PR add -L option to curl command. 
For arm architecture it uses  mirror.archlinuxarm.org as repository. However it returns http status 302 to client, so curl command needs to add -L option to follow redirection.

checking response fro repo.
$ curl -I -s http://mirror.archlinuxarm.org | grep "HTTP/1.1"
HTTP/1.1 302 Found

so, if -L option is not set, getting package fails.
$ sudo bash arch-bootstrap.sh -a armv6h ./bootstrap/
--- destination directory: ./bootstrap/
--- core repository: http://mirror.archlinuxarm.org/armv6h/core
--- temporary directory: /tmp/tmp.WhYeavbo5x
--- fetch packages list: http://mirror.archlinuxarm.org/armv6h/core/
--- pacman package and dependencies: acl archlinux-keyring attr bzip2
curl expat glibc gpgme libarchive libassuan libgpg-error libssh2 lzo
openssl pacman pacman-mirrorlist xz zlib krb5 e2fsprogs keyutils libidn
gcc-libs filesystem
--- Error: cannot find package: acl