### PR TITLE
Add lz4 package to PACMAN_PACKAGES

### DIFF
--- a/arch-bootstrap.sh
+++ b/arch-bootstrap.sh
@@ -24,7 +24,7 @@ set -e -u -o pipefail
 PACMAN_PACKAGES=(
   acl archlinux-keyring attr bzip2 curl expat glibc gpgme libarchive
   libassuan libgpg-error libssh2 lzo openssl pacman pacman-mirrorlist xz zlib
-  krb5 e2fsprogs keyutils libidn gcc-libs
+  krb5 e2fsprogs keyutils libidn gcc-libs lz4
 )
 BASIC_PACKAGES=(${PACMAN_PACKAGES[*]} filesystem)
 EXTRA_PACKAGES=(coreutils bash grep gawk file tar systemd sed)


### PR DESCRIPTION
I got following error. So, added lz4 package to PACMAN_PACKAGES.

--- uncompress package:
/tmp/tmp.ebTFfe0JoL/filesystem-2015.09-1-x86_64.pkg.tar.xz
--- configure DNS and pacman
--- install packages: acl archlinux-keyring attr bzip2 curl expat glibc
gpgme libarchive libassuan libgpg-error libssh2 lzo openssl pacman
pacman-mirrorlist xz zlib krb5 e2fsprogs keyutils libidn gcc-libs
filesystem coreutils bash grep gawk file tar systemd sed
/usr/bin/pacman: error while loading shared libraries: liblz4.so.1:
cannot open shared object file: No such file or directory