### PR TITLE
Edit rather than overwrite /etc/shadow from filesystem pkg

### DIFF
--- a/arch-bootstrap.sh
+++ b/arch-bootstrap.sh
@@ -108,8 +108,7 @@ configure_minimal_system() {
   local DEST=$1
   
   mkdir -p "$DEST/dev"
-  echo "root:x:0:0:root:/root:/bin/bash" > "$DEST/etc/passwd" 
-  echo 'root:$1$GT9AUpJe$oXANVIjIzcnmOpY07iaGi/:14657::::::' > "$DEST/etc/shadow"
+  sed -ie 's/^root:.*$/root:$1$GT9AUpJe$oXANVIjIzcnmOpY07iaGi\/:14657::::::/' $DEST/etc/shadow
   touch "$DEST/etc/group"
   echo "bootstrap" > "$DEST/etc/hostname"
   


### PR DESCRIPTION
Edit, rather than overwrite the `/etc/shadow` unpacked from the `filesystem` package. Otherwise many several users expected in the installed system (e.g. dbus) will not be present in the installed system.