### PR TITLE
icu and libpsl coming up as dependencies for pacman

### DIFF
--- a/arch-bootstrap.sh
+++ b/arch-bootstrap.sh
@@ -24,7 +24,7 @@ set -e -u -o pipefail
 PACMAN_PACKAGES=(
   acl archlinux-keyring attr bzip2 curl expat glibc gpgme libarchive
   libassuan libgpg-error libssh2 lzo openssl pacman pacman-mirrorlist xz zlib
-  krb5 e2fsprogs keyutils libidn gcc-libs lz4
+  krb5 e2fsprogs keyutils libidn gcc-libs lz4 libpsl icu
 )
 BASIC_PACKAGES=(${PACMAN_PACKAGES[*]} filesystem)
 EXTRA_PACKAGES=(coreutils bash grep gawk file tar systemd sed)


### PR DESCRIPTION
Hello -- this change is now required on the x86_64 platform to get arch-bootstrap work again.