### PR TITLE
added zstd to the arch the PACMAN_PACKAGES

### DIFF
--- a/arch-bootstrap.sh
+++ b/arch-bootstrap.sh
@@ -24,7 +24,7 @@ set -e -u -o pipefail
 PACMAN_PACKAGES=(
   acl archlinux-keyring attr bzip2 curl expat glibc gpgme libarchive
   libassuan libgpg-error libnghttp2 libssh2 lzo openssl pacman pacman-mirrorlist xz zlib
-  krb5 e2fsprogs keyutils libidn2 libunistring gcc-libs lz4 libpsl icu libunistring
+  krb5 e2fsprogs keyutils libidn2 libunistring gcc-libs lz4 libpsl icu libunistring zstd
 )
 BASIC_PACKAGES=(${PACMAN_PACKAGES[*]} filesystem)
 EXTRA_PACKAGES=(coreutils bash grep gawk file tar systemd sed)


### PR DESCRIPTION
recently chroot started failing. the simple fix is adding zstd to the
PACMAN_PACKAGES

The error:
/usr/bin/pacman: error while loading shared libraries: libzstd.so.1: cannot open shared object file: No such file or directory