### PR TITLE
Support pacman >= 5.1

### DIFF
--- a/arch-bootstrap.sh
+++ b/arch-bootstrap.sh
@@ -163,7 +163,7 @@ install_packages() {
   local ARCH=$1 DEST=$2 PACKAGES=$3
   debug "install packages: $PACKAGES"
   LC_ALL=C chroot "$DEST" /usr/bin/pacman \
-    --noconfirm --arch $ARCH -Sy --force $PACKAGES
+    --noconfirm --arch $ARCH -Sy --overwrite='*' $PACKAGES
 }
 
 show_usage() {


### PR DESCRIPTION
This change is needed for pacman version >= 5.1 because `--force` has been removed in favor of `--overwrite`.
See http://allanmcrae.com/2018/05/pacman-5-1-dont-use-the-force-luke/