### PR TITLE
Add brotli to pacman packages

### DIFF
--- a/arch-bootstrap.sh
+++ b/arch-bootstrap.sh
@@ -22,7 +22,7 @@ set -e -u -o pipefail
 
 # Packages needed by pacman (see get-pacman-dependencies.sh)
 PACMAN_PACKAGES=(
-  acl archlinux-keyring attr bzip2 curl expat glibc gpgme libarchive
+  acl archlinux-keyring attr brotli bzip2 curl expat glibc gpgme libarchive
   libassuan libgpg-error libnghttp2 libssh2 lzo openssl pacman pacman-mirrorlist xz zlib
   krb5 e2fsprogs keyutils libidn2 libunistring gcc-libs lz4 libpsl icu libunistring zstd
 )


### PR DESCRIPTION
Hi. I tried to use this project to bootstrap a new arch environment from my current Ubuntu 20.04. When I ran the `arch-bootstrap.sh` script, I got an error:

```
--- configure DNS and pacman
--- install packages: acl archlinux-keyring attr bzip2 curl expat glibc gpgme libarchive libassuan libgpg-error libnghttp2 libssh2 lzo openssl pacman pacman-mirrorlist xz zlib krb5 e2fsprogs keyutils libidn2 libunistring gcc-libs lz4 libpsl icu libunistring zstd filesystem coreutils bash grep gawk file tar systemd sed
/usr/bin/pacman: error while loading shared libraries: libbrotlidec.so.1: cannot open shared object file: No such file or directory
```

After a quick searching, I found that the missing shared library is coming from [brotli](https://archlinux.org/packages/core/x86_64/brotli/), so I added it to the `PACMAN_PACKAGES` list. It solved the issue for me, so I opened this PR if anybody else has the same problem