### PR TITLE
Add gzip and base packages

### DIFF
--- a/arch-bootstrap.sh
+++ b/arch-bootstrap.sh
@@ -26,7 +26,7 @@ PACMAN_PACKAGES=(
   libassuan libgpg-error libnghttp2 libssh2 lzo openssl pacman pacman-mirrorlist xz zlib
   krb5 e2fsprogs keyutils libidn2 libunistring gcc-libs lz4 libpsl icu libunistring zstd
 )
-BASIC_PACKAGES=(${PACMAN_PACKAGES[*]} filesystem)
+BASIC_PACKAGES=(${PACMAN_PACKAGES[*]} filesystem base)
 EXTRA_PACKAGES=(coreutils bash grep gawk file tar gzip systemd sed)
 DEFAULT_REPO_URL="http://mirrors.kernel.org/archlinux"
 DEFAULT_ARM_REPO_URL="http://mirror.archlinuxarm.org"

--- a/arch-bootstrap.sh
+++ b/arch-bootstrap.sh
@@ -27,7 +27,7 @@ PACMAN_PACKAGES=(
   krb5 e2fsprogs keyutils libidn2 libunistring gcc-libs lz4 libpsl icu libunistring zstd
 )
 BASIC_PACKAGES=(${PACMAN_PACKAGES[*]} filesystem)
-EXTRA_PACKAGES=(coreutils bash grep gawk file tar systemd sed)
+EXTRA_PACKAGES=(coreutils bash grep gawk file tar gzip systemd sed)
 DEFAULT_REPO_URL="http://mirrors.kernel.org/archlinux"
 DEFAULT_ARM_REPO_URL="http://mirror.archlinuxarm.org"
 


### PR DESCRIPTION
Add gzip package as dependency

glibc does not mandate **gzip**, but skips processing of locales silently if not
present. This results confusing error messages when trying to generate locales
with locale-gen afterwards.

Add Arch Linux base meta package

**base** meta package provides the additional Arch Linux base packages
for the minimal up-to-date basic base configuration which should
be expected for the base install.
